### PR TITLE
Fix(gemini): Resolve SyntaxError (missing types) in gemini_service.py

### DIFF
--- a/src/services/gemini_service.py
+++ b/src/services/gemini_service.py
@@ -3,7 +3,7 @@ import sys
 import logging
 import google.generativeai as genai
 from google.generativeai.types import File
-from typing import Optional
+from typing import Optional, List, Dict, Any
 
 # Set up logger
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Fix(gemini): Resolve SyntaxError (missing types) in gemini_service.py

**Description**

This pull request resolves a SyntaxError in src/services/gemini_service.py that prevented the application server from starting. The error was caused by missing type hint imports.

**Changes**

Added Missing Imports: Imported List, Dict, and Any from the typing module to correctly handle type hinting in function signatures.

**Reasoning**

The syntax error was a blocker that made the service non-functional. The missing imports caused NameError exceptions. 