### PR TITLE
Add glama.json with maintainers

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "froockle",
+    "tanmayjain-bit"
+  ]
+}


### PR DESCRIPTION
Adds glama.json declaring MCP server maintainers for Glama listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)